### PR TITLE
`CuckooSet` Comparison Operations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ name: Test
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   pull_request:
-    branches: [master]
+    branches: ['**']
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,8 @@
 .DS_Store
 .build
-/Packages
-/*.xcodeproj
-xcuserdata/
-DerivedData/
+Packages
+xcuserdata
+DerivedData
 .swiftpm
-.vscode 
-.vscode/launch.json
+.vscode
 Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .package(
             name: "FowlerNollVo", 
             url: "https://github.com/crichez/swift-fowler-noll-vo",
-            .upToNextMinor(from: "0.1.0"))
+            .upToNextMinor(from: "0.1.1"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/CuckooCollections/CuckooSet/ComparisonOperations.swift
+++ b/Sources/CuckooCollections/CuckooSet/ComparisonOperations.swift
@@ -1,0 +1,67 @@
+//
+//  ComparisonOperations.swift
+//  CuckooSet
+//
+//  Created by Christopher Richez on January 10 2022
+//
+
+import FowlerNollVo
+
+extension CuckooSet: FNVHashable, Equatable {
+    public func hash<Hasher>(into hasher: inout Hasher) where Hasher : FNVHasher {
+        for element in self {
+            hasher.combine(element)
+        }
+    }
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        var lhsHasher = FNV1aHasher<UInt64>()
+        var rhsHasher = FNV1aHasher<UInt64>()
+        lhs.hash(into: &lhsHasher)
+        rhs.hash(into: &rhsHasher)
+        return lhsHasher.digest == rhsHasher.digest
+    }
+}
+
+extension CuckooSet/*: SetAlgebra*/ {
+    /// Returns true if the set provided for comparison contains all of this set's elements.
+    public func isSubset(of other: Self) -> Bool {
+        for element in self where !other.contains(element) {
+            return false
+        }
+        return true
+    }
+
+    /// Returns true of the set provided for comparison contains all of this set's elements,
+    /// but false if the sets are identical.
+    public func isStrictSubset(of other: Self) -> Bool {
+        guard self != other else { return false }
+        return isSubset(of: other)
+    }
+
+    /// Returns true if this set contains all elements of the set provided for comparison.
+    public func isSuperset(of other: Self) -> Bool {
+        for element in other where !self.contains(element) {
+            return false
+        }
+        return true
+    }
+
+    /// Returns true if this set contains all elements of the set provided for comparison,
+    /// but false if the sets are identical.
+    public func isStrictSuperset(of other: Self) -> Bool {
+        guard self != other else { return false }
+        return isSuperset(of: other)
+    }
+
+    /// Returns true if the set provided for comparison has no elements in common with this set.
+    public func isDisjoint(with other: Self) -> Bool {
+        for element in self where other.contains(element) {
+            return false
+        }
+        for element in other where self.contains(element) {
+            return false
+        }
+        return true
+    }
+}

--- a/Sources/CuckooCollections/CuckooSet/CuckooSet.swift
+++ b/Sources/CuckooCollections/CuckooSet/CuckooSet.swift
@@ -334,3 +334,14 @@ extension CuckooSet where Element : Hashable {
         self = cuckooSet
     }
 }
+
+extension CuckooSet: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        var description = "CuckooSet<\(Element.self)>([\n"
+        for element in self {
+            description.append("    \(element),\n")
+        }
+        description.append("])")
+        return description
+    }
+}

--- a/Tests/CuckooCollectionsTests/CuckooSet/ComparisonOperationsTests.swift
+++ b/Tests/CuckooCollectionsTests/CuckooSet/ComparisonOperationsTests.swift
@@ -1,0 +1,136 @@
+//
+//  ComparisonOperationsTests.swift
+//
+//
+//  Created by Christopher Richez on January 10 2022
+//
+
+import CuckooCollections
+import XCTest
+
+/// The test case for the methods contained in 
+/// the `Sources/CuckooCollections/CuckooSet/ComparisonOperations.swift` file
+class ComparisonOperationsTests: XCTestCase {
+    /// Asserts two sets with different capacities that contain the same elements should be equal.
+    func testEqualityWithDifferentCapacity() {
+        var set1 = CuckooSet<Double>(capacity: 16)
+        var set2 = CuckooSet<Double>(capacity: 32)
+
+        set1.insert(1.295)
+        XCTAssertEqual(set1.capacity, 16, "set1 expanded, use different inputs")
+        XCTAssertNotEqual(set1, set2, "sets reported equality with different elements")
+        set2.insert(1.295)
+        XCTAssertEqual(set2.capacity, 32, "set2 expanded, use different inputs")
+        XCTAssertEqual(set1, set2)
+
+        set1.insert(-0.999)
+        XCTAssertEqual(set1.capacity, 16, "set1 expanded, use different inputs")
+        XCTAssertNotEqual(set1, set2, "sets reported equality with different elements")
+        set2.insert(-0.999)
+        XCTAssertEqual(set2.capacity, 32, "set2 expanded, use different inputs")
+        XCTAssertEqual(set1, set2)
+
+        set1.insert(9.333)
+        XCTAssertEqual(set1.capacity, 16, "set1 expanded, use different inputs")
+        XCTAssertNotEqual(set1, set2, "sets reported equality with different elements")
+        set2.insert(9.333)
+        XCTAssertEqual(set2.capacity, 32, "set2 expanded, use different inputs")
+        XCTAssertEqual(set1, set2)
+    }
+
+    /// Asserts two sets with identical capacities that contain the same elements should be equal.
+    func testEqualityWithSameCapacity() throws {
+        var set1 = CuckooSet<Double>(capacity: 32)
+        var set2 = CuckooSet<Double>(capacity: 32)
+
+        set1.insert(1.295)
+        XCTAssertEqual(set1.capacity, 32, "set1 expanded, use different inputs")
+        XCTAssertNotEqual(set1, set2, "sets reported equality with different elements")
+        set2.insert(1.295)
+        XCTAssertEqual(set2.capacity, 32, "set2 expanded, use different inputs")
+        XCTAssertEqual(set1, set2)
+
+        set1.insert(-0.999)
+        XCTAssertEqual(set1.capacity, 32, "set1 expanded, use different inputs")
+        XCTAssertNotEqual(set1, set2, "sets reported equality with different elements")
+        set2.insert(-0.999)
+        XCTAssertEqual(set2.capacity, 32, "set2 expanded, use different inputs")
+        XCTAssertEqual(set1, set2)
+
+        set1.insert(9.333)
+        XCTAssertEqual(set1.capacity, 32, "set1 expanded, use different inputs")
+        XCTAssertNotEqual(set1, set2, "sets reported equality with different elements")
+        set2.insert(9.333)
+        XCTAssertEqual(set2.capacity, 32, "set2 expanded, use different inputs")
+        XCTAssertEqual(set1, set2)
+    }
+
+    /// Asserts a set with only some elements in common with another is a subset of that other set.
+    func testSubset() throws {
+        let superset: CuckooSet<Float?> = [nil, 0.0, -9.091, 0.887]
+        let subset: CuckooSet<Float?> = [0.0, -9.091, 0.887]
+        XCTAssertTrue(subset.isSubset(of: superset), "incorrect subset evaluation")
+    }
+
+    /// Asserts two identical sets are subsets of one another.
+    func testSubsetIfEqual() throws {
+        let superset: CuckooSet<Float?> = [nil, 0.0, -9.091, 0.887]
+        let subset = superset
+        XCTAssertTrue(subset.isSubset(of: superset), "subset evaluation failed")
+        XCTAssertTrue(superset.isSubset(of: subset), "subset evaluation failed")
+    }
+
+    /// Asserts a set with only some elements in common with another is a strict subset of that other set.
+    func testStrictSubset() throws {
+        let superset: CuckooSet<Float?> = [nil, 0.0, -9.091, 0.887]
+        let subset: CuckooSet<Float?> = [0.0, -9.091, 0.887]
+        #warning("this test is failing if the only difference between the sets is a nil")
+        #warning("this probably has to do with the hash function, need to investigate")
+        XCTAssertTrue(subset.isStrictSubset(of: superset), "incorrect strict subset evaluation")
+    }
+
+    /// Asserts two identical sets are not strict subsets of one another.
+    func testNotStrictSubsetIfEqual() throws {
+        let superset: CuckooSet<Float?> = [nil, 0.0, -9.091, 0.887]
+        let subset = superset
+        XCTAssertFalse(subset.isStrictSubset(of: superset), "strict subset evaluation failed")
+    }
+
+    /// Asserts a set with all of the elements of another and more is a superset of that other set.
+    func testSuperset() throws {
+        let superset: CuckooSet<Float?> = [nil, 0.0, -9.091, 0.887]
+        let subset: CuckooSet<Float?> = [0.0, -9.091, 0.887]
+        XCTAssertTrue(superset.isSuperset(of: subset), "superset evaluation failed")
+    }
+
+    /// Asserts two identical sets are supersets of one another.
+    func testSupersetIfEqual() throws {
+        let superset: CuckooSet<Float?> = [nil, 0.0, -9.091, 0.887]
+        let subset: CuckooSet<Float?> = superset
+        XCTAssertTrue(superset.isSuperset(of: subset), "superset evaluation failed")
+        XCTAssertTrue(subset.isSuperset(of: superset), "superset evaluation failed")
+    }
+
+    /// Asserts a set with all of the elements of another and more is a struct superset of that other set.
+    func testStrictSuperset() throws {
+        let superset: CuckooSet<Float?> = [nil, 0.0, -9.091, 0.887]
+        let subset: CuckooSet<Float?> = [0.0, -9.091, 0.887]
+        #warning("this test is failing if the only difference between the sets is a nil")
+        #warning("this probably has to do with the hash function, need to investigate")
+        XCTAssertTrue(superset.isStrictSuperset(of: subset), "strict superset evaluation failed")
+    }
+
+    /// Asserts two identical sets are not strict supersets of one another.
+    func testNotStrictSupersetIfEqual() throws {
+        let superset: CuckooSet<Float?> = [nil, 0.0, -9.091, 0.887]
+        let subset: CuckooSet<Float?> = superset
+        XCTAssertFalse(superset.isStrictSuperset(of: subset), "strict superset evaluation failed")
+    }
+
+    /// Asserts two sets with no elements in common are disjoint from one another.
+    func testDisjoint() throws {
+        let set1: CuckooSet<String> = ["one", "two", "three"]
+        let set2: CuckooSet<String> = ["four", "five", "six"]
+        XCTAssertTrue(set1.isDisjoint(with: set2), "disjoint evaluation failed")
+    }
+}

--- a/Tests/CuckooCollectionsTests/CuckooSet/ComparisonOperationsTests.swift
+++ b/Tests/CuckooCollectionsTests/CuckooSet/ComparisonOperationsTests.swift
@@ -65,6 +65,13 @@ class ComparisonOperationsTests: XCTestCase {
         XCTAssertEqual(set1, set2)
     }
 
+    /// Asserts the presence of `nil` optionals in a set affects its equality to another set.
+    func testEqualityWithNilOptionals() {
+        let set1: CuckooSet<String?> = ["this", "is", "a", "test"]
+        let set2: CuckooSet<String?> = [nil, "this", "is", "a", "test"]
+        XCTAssertNotEqual(set1, set2, "different sets unexpectedly reported equality")
+    }
+
     /// Asserts a set with only some elements in common with another is a subset of that other set.
     func testSubset() throws {
         let superset: CuckooSet<Float?> = [nil, 0.0, -9.091, 0.887]

--- a/Tests/CuckooCollectionsTests/CuckooSet/ComparisonOperationsTests.swift
+++ b/Tests/CuckooCollectionsTests/CuckooSet/ComparisonOperationsTests.swift
@@ -91,8 +91,6 @@ class ComparisonOperationsTests: XCTestCase {
     func testStrictSubset() throws {
         let superset: CuckooSet<Float?> = [nil, 0.0, -9.091, 0.887]
         let subset: CuckooSet<Float?> = [0.0, -9.091, 0.887]
-        #warning("this test is failing if the only difference between the sets is a nil")
-        #warning("this probably has to do with the hash function, need to investigate")
         XCTAssertTrue(subset.isStrictSubset(of: superset), "incorrect strict subset evaluation")
     }
 
@@ -122,8 +120,6 @@ class ComparisonOperationsTests: XCTestCase {
     func testStrictSuperset() throws {
         let superset: CuckooSet<Float?> = [nil, 0.0, -9.091, 0.887]
         let subset: CuckooSet<Float?> = [0.0, -9.091, 0.887]
-        #warning("this test is failing if the only difference between the sets is a nil")
-        #warning("this probably has to do with the hash function, need to investigate")
         XCTAssertTrue(superset.isStrictSuperset(of: subset), "strict superset evaluation failed")
     }
 

--- a/Tests/CuckooCollectionsTests/CuckooSet/CuckooSetTests.swift
+++ b/Tests/CuckooCollectionsTests/CuckooSet/CuckooSetTests.swift
@@ -86,4 +86,17 @@ class CuckooSetTests: XCTestCase {
             }
         }
     }
+
+    func testDebugDescription() {
+        let testSet: CuckooSet<String> = ["this", "is", "a", "test"]
+        let expectedDescription = """
+        CuckooSet<String>([
+            this,
+            test,
+            a,
+            is,
+        ])
+        """
+        XCTAssertEqual(testSet.debugDescription, expectedDescription)
+    }
 }


### PR DESCRIPTION
### Objectives

This pull request adds the following comparison operations to `CuckooSet`:
* `== (lhs:rhs:)`
* `isSubset(of:)`
* `isStrictSubset(of:)`
* `isSuperset(of:)`
* `isStrictSuperset(of:)`
* `isDisjoint(with:)`

`CuckooSet` also unconditionally conforms to `FNVHashable`.

### Tasks

- [x] declare methods
- [x] write unit tests
- [ ] implement methods
- [ ] pass & refine tests
- [ ] write documentation
