### PR TITLE
Optimize `CuckooSet`

### DIFF
--- a/Sources/CuckooCollections/CuckooSet/CuckooSet.swift
+++ b/Sources/CuckooCollections/CuckooSet/CuckooSet.swift
@@ -12,19 +12,8 @@ import FowlerNollVo
 /// `CuckooSet` conforms to `SetAlgebra` and exposes the same API as the Swift standard
 /// library `Set`, but requires that `Element` conform to `FNVHashable`.
 public struct CuckooSet<Element: FNVHashable> {
-    /// A value that contains the state of a hash table bucket.
-    enum Bucket {
-        /// The bucket is empty.
-        case none
-
-        /// The bucket contains a set member.
-        ///
-        /// The value includes the assigned hash value of the member and the member itself.
-        case some(UInt64, Element)
-    }
-
     /// An array of `Bucket` cases used as storage for the set.
-    var buckets: [Bucket]
+    var buckets: [Element?]
 
     /// Initializes an empty `CuckooSet` with the provided capacity.
     ///
@@ -34,7 +23,7 @@ public struct CuckooSet<Element: FNVHashable> {
     /// `capacity`. When allocating a set to store a known number of members, request
     /// a capacity of at least double the number of members.
     public init(capacity: Int = 32) {
-        self.buckets = [Bucket](repeating: .none, count: capacity)
+        self.buckets = [Element?](repeating: nil, count: capacity)
         self.count = 0
     }
 
@@ -86,23 +75,6 @@ public struct CuckooSet<Element: FNVHashable> {
         Int(hash % UInt64(capacity))
     }
 
-    /// Retrieves the contents of the specified bucket.
-    ///
-    /// - bucket: the index of the hash table bucket to retrieve the contents of
-    ///
-    /// - Returns: A tuple where `hash` is either the primary or secondary hash 
-    /// of the stored element, and `element` is the stored element itself. If the bucket
-    /// is empty, returns `nil`.
-    func contents(ofBucket bucket: Int) -> (hash: UInt64, element: Element)? {
-        guard bucket < capacity else { fatalError("tried to fetch a bucket out of bounds") }
-        switch buckets[bucket] {
-        case .none:
-            return nil
-        case .some(let hash, let element): 
-            return (hash: hash, element: element)
-        }
-    }
-
     /// Doubles the number of buckets in the set, then re-inserts every element.
     mutating func expand() {
         var expandedSet = CuckooSet<Element>(capacity: capacity * 2)
@@ -112,56 +84,37 @@ public struct CuckooSet<Element: FNVHashable> {
         self = expandedSet
     }
 
-    /// Clears the specified occupied bucket and inserts a new member in its place.
-    ///
-    /// This method reorganizes the hash table to guarantee the new member can be stored,
-    /// and may call itself recursively up to 20 times before expanding and re-hashing.
+    /// Moves the provided member into the specified bucket, 
+    /// and optionally returns the bumped element.
     ///
     /// - Parameters:
     ///     - bucket: the bucket to clear and insert the new member into
     ///     - newMember: the new member to insert at the specified bucket
-    ///     - atPrimaryLocation: whether the new member is being inserted at its primary location
-    ///     - iteration: the number of times `bump` was called for a single insertion
     ///
-    /// - Returns: A tuple that is the result of calling `insert(_:)` after clearing the bucket.
-    mutating func bump(
-        bucket: Int, 
-        for newMember: Element, 
-        atPrimaryLocation: Bool, 
-        iteration: Int = 0
-    ) -> (inserted: Bool, memberAfterInsert: Element) {
-        // At iteration 20 we are probably in a loop, 
-        // so expand the set's storage to reduce the collision rate
-        guard iteration < 20 else { expand(); return insert(newMember) }
-
+    /// - Returns:
+    /// Returns `nil` if the new member and bumped member were assigned to a bucket.
+    /// If the alternative bucket for the bumped member is full, 
+    /// returns a tuple containing the bumped member and its alternative bucket.
+    mutating func bump(bucket: Int, for newMember: Element) -> (member: Element, bucket: Int)? {
         // Fetch the current contents of the bucket
-        guard let (hash, element) = contents(ofBucket: bucket) else {
+        guard let bumpedMember = buckets[bucket] else {
             fatalError("requested a bump from an empty bucket")
         }
-
-        // Overwrite it with the new element
-        let newHash = atPrimaryLocation ? primaryHash(of: newMember) : secondaryHash(of: newMember)
-        buckets[bucket] = .some(newHash, newMember)
-
-        // Find out if the bumped element is at its primary or secondary bucket
-        let primaryHash = primaryHash(of: element)
-        let secondaryHash = secondaryHash(of: element)
-        let bumpToSecondary = hash == primaryHash
-        let newBumpedHash = bumpToSecondary ? secondaryHash : primaryHash
-
-        // Move the element to its alternative bucket
-        let destinationBucket = self.bucket(for: newBumpedHash)
-        if contents(ofBucket: destinationBucket) == nil {
-            // If the secondary location is empty, insert it directly
-            buckets[destinationBucket] = .some(newBumpedHash, element)
-            return (true, newMember)
+        // Overwrite the bucket with the new element
+        buckets[bucket] = newMember
+        // Get the new bucket of the bumped member
+        let hash1 = primaryHash(of: bumpedMember)
+        let hash2 = secondaryHash(of: bumpedMember)
+        let bucket1 = self.bucket(for: hash1)
+        let bucket2 = self.bucket(for: hash2)
+        let isAtBucket1 = bucket1 == bucket
+        let newBucket = isAtBucket1 ? bucket2 : bucket1
+        // Check whether the new bucket is occupied
+        if buckets[newBucket] == nil {
+            buckets[newBucket] = bumpedMember
+            return nil
         } else {
-            // If the secondary location if full, request a bump
-            return bump(
-                bucket: destinationBucket, 
-                for: element, 
-                atPrimaryLocation: !bumpToSecondary, 
-                iteration: iteration + 1)
+            return (bumpedMember, newBucket)
         }
     }
 
@@ -176,26 +129,21 @@ public struct CuckooSet<Element: FNVHashable> {
     }
 
     public func contains(_ member: Element) -> Bool {
+        // Get the hashes and buckets for the new member
         let hash1 = primaryHash(of: member)
-        let bucket1 = bucket(for: hash1)
         let hash2 = secondaryHash(of: member)
+        let bucket1 = bucket(for: hash1)
         let bucket2 = bucket(for: hash2)
-
-        if let (_, memberFound) = contents(ofBucket: bucket1) {
-            let foundHash1 = primaryHash(of: memberFound)
-            let foundHash2 = secondaryHash(of: memberFound)
-            if foundHash1 == hash1 && foundHash2 == hash2 {
-                return true
+        // Check both buckets
+        for bucket in [bucket1, bucket2] {
+            if let memberFound = buckets[bucket] {
+                let foundHash1 = primaryHash(of: memberFound)
+                let foundHash2 = secondaryHash(of: memberFound)
+                if foundHash1 == hash1 && foundHash2 == hash2 {
+                    return true
+                }
             }
         }
-        if let (_, memberFound) = contents(ofBucket: bucket2) {
-            let foundHash1 = primaryHash(of: memberFound)
-            let foundHash2 = secondaryHash(of: memberFound)
-            if foundHash1 == hash1 && foundHash2 == hash2 {
-                return true
-            }
-        }
-
         // If we havent found anything yet, return false
         return false
     }
@@ -204,21 +152,13 @@ public struct CuckooSet<Element: FNVHashable> {
     ///
     /// This method removes all elements by overwriting the set's storage.
     public mutating func removeAll() {
-        buckets = [Bucket](repeating: .none, count: capacity)
+        buckets = [Element?](repeating: nil, count: capacity)
     }
 }
 
 extension CuckooSet: Sequence {
     public func makeIterator() -> IndexingIterator<[Element]> {
-        buckets.compactMap { bucket in
-            switch bucket {
-            case .none:
-                return nil
-            case .some(_, let element):
-                return element
-            }
-        }
-        .makeIterator()
+        buckets.compactMap { $0 }.makeIterator()
     }
 }
 

--- a/Sources/CuckooCollections/CuckooSet/SetAlgebra.swift
+++ b/Sources/CuckooCollections/CuckooSet/SetAlgebra.swift
@@ -90,103 +90,71 @@ extension CuckooSet: SetAlgebra {
     public mutating func insert(
         _ newMember: Element
     ) -> (inserted: Bool, memberAfterInsert: Element) {
-        // Keep the load factor of the table under 0.5
+        // Keep the load factor of the hash table under 0.5
         if capacity < count * 2 { expand() }
-
-        // Get the primary hash and bucket for the new element
-        let primaryHash = primaryHash(of: newMember)
-        let primaryBucket = bucket(for: primaryHash)
-        // Optionally, get the reported hash and element that occupies that bucket
-        let hashOfPrimaryElement = contents(ofBucket: primaryBucket)?.hash
-        let elementAtPrimaryBucket = contents(ofBucket: primaryBucket)?.element
-
-        // Get the secondary hash and bucket for the new element
-        let secondaryHash = secondaryHash(of: newMember)
-        let secondaryBucket = bucket(for: secondaryHash)
-        // Optionally, get the reported hash and element that occupies that bucket
-        let hashOfSecondaryElement = contents(ofBucket: secondaryBucket)?.hash
-        let elementAtSecondaryBucket = contents(ofBucket: secondaryBucket)?.element
-
-        // Check whether an element exists at the primary bucket
-        // Check whether that element has the same primary hash as the new element
-        if let existingElement = elementAtPrimaryBucket, hashOfPrimaryElement == primaryHash {
-            /// The primary hash of the element found at the primary bucket.
-            let hash1 = self.primaryHash(of: existingElement)
-            /// The secondary hash of the element found at the primary bucket.
-            let hash2 = self.secondaryHash(of: existingElement)
-            // Check whether both hashes of the existing element match those of the new element
-            if hash1 == primaryHash && hash2 == secondaryHash {
-                // If so, these are likely the same element
-                return (inserted: false, memberAfterInsert: existingElement)
-            } else {
-                // If not, these are not the same element
-                /// Whether the element at the primary bucket is hashed at its primary location.
-                let isAtPrimaryLocation = hash1 == hashOfPrimaryElement
-                // Bump the existing element to its alternative bucket
-                count += 1
-                return bump(bucket: primaryBucket, for: newMember, atPrimaryLocation: isAtPrimaryLocation) 
+        // Get the hashes and buckets for the new member
+        let hash1 = primaryHash(of: newMember)
+        let hash2 = secondaryHash(of: newMember)
+        let bucket1 = bucket(for: hash1)
+        let bucket2 = bucket(for: hash2)
+        // Check for an existing member at both buckets
+        for bucket in [bucket1, bucket2] {
+            if let memberFound = buckets[bucket] {
+                let memberFoundHash1 = primaryHash(of: memberFound)
+                let memberFoundHash2 = secondaryHash(of: memberFound)
+                if memberFoundHash1 == hash1 && memberFoundHash2 == hash2 {
+                    return (inserted: false, memberAfterInsert: memberFound)
+                }
             }
-        // Check whether an element exists at the secondary bucket
-        // Check whether that element has the same secondary hash as the new element
-        } else if let existingElement = elementAtSecondaryBucket, hashOfSecondaryElement == secondaryHash {
-            /// The primary hash of the element found at the secondary bucket.
-            let hash1 = self.primaryHash(of: existingElement)
-            /// The secondary hash of the element found at the secondary bucket.
-            let hash2 = self.secondaryHash(of: existingElement)
-            // Check whether both hashes of the existing element match those of the new element
-            if hash1 == primaryHash && hash2 == secondaryHash {
-                // If so, these are likely the same element
-                return (inserted: false, memberAfterInsert: existingElement)
-            } else {
-                // If not, these are not the same element
-                /// Whether the element at the secondary bucket is hashed at its primary location
-                let isAtPrimaryLocation = hash1 == hashOfSecondaryElement
-                // Bump the existing element to its alternative bucket
-                count += 1
-                return bump(bucket: secondaryBucket, for: newMember, atPrimaryLocation: isAtPrimaryLocation)
-            }
-        // If neither of the previous patterns matched, the element does not already exist
+        }
+        // If no existing member was found, check the primary bucket
+        if buckets[bucket1] == nil {
+            // If it's empty, assign the new member and increment count
+            buckets[bucket1] = newMember
+            count += 1
+            return (inserted: true, memberAfterInsert: newMember)
         } else {
-            // Check if the primary bucket is free
-            if hashOfPrimaryElement == nil {
-                // If it is, insert it directly
-                buckets[primaryBucket] = .some(primaryHash, newMember)
-                count += 1
-                return (inserted: true, memberAfterInsert: newMember)
-            } else {
-                // If it is not, request a bump and insert it later
-                count += 1
-                return bump(bucket: primaryBucket, for: newMember, atPrimaryLocation: true)
+            // If it's full, prepare to bump its member
+            var bumped = (member: newMember, bucket: bucket1)
+            // Keep track of the number of consecutive bumps for this insertion
+            var bumpCount = 0
+            // Keep bumping until the method returns nil
+            while let nextBump = bump(bucket: bumped.bucket, for: bumped.member) {
+                // Expand and retry if we hit 20 consicutive bumps
+                guard bumpCount < 20 else {
+                    expand()
+                    return insert(nextBump.member)
+                }
+                bumpCount += 1
+                bumped = nextBump
             }
+            // Once we are done bumping, increment the count and report success
+            count += 1
+            return (inserted: true, memberAfterInsert: newMember)
         }
     }
 
     /// Removes the specified element from the set.
     @discardableResult
     public mutating func remove(_ member: Element) -> Element? {
+        // Get the hashes and buckets for the member to remove
         let hash1 = primaryHash(of: member)
         let bucket1 = bucket(for: hash1)
         let hash2 = secondaryHash(of: member)
         let bucket2 = bucket(for: hash2)
-
-        if let (_, memberFound) = contents(ofBucket: bucket1) {
-            let foundHash1 = primaryHash(of: memberFound)
-            let foundHash2 = secondaryHash(of: memberFound)
-            if foundHash1 == hash1 && foundHash2 == hash2 {
-                buckets[bucket1] = .none
-                count -= 1
-                return member
-            }
-        } 
-        if let (_, memberFound) = contents(ofBucket: bucket2) {
-            let foundHash1 = primaryHash(of: memberFound)
-            let foundHash2 = secondaryHash(of: memberFound)
-            if foundHash1 == hash1 && foundHash2 == hash2 {
-                buckets[bucket2] = .none
-                count -= 1
-                return member
-            }
+        // Check both buckets
+        for bucket in [bucket1, bucket2] {
+            if let memberFound = buckets[bucket] {
+                let foundHash1 = primaryHash(of: memberFound)
+                let foundHash2 = secondaryHash(of: memberFound)
+                if foundHash1 == hash1 && foundHash2 == hash2 {
+                    buckets[bucket1] = nil
+                    count -= 1
+                    return member
+                }
+            } 
         }
+        // If no matches were found, report the member was not removed
         return nil
     }
 


### PR DESCRIPTION
### Objectives

This pull request refactors the bump and insertion process for `CuckooSet` for clarity and to better match `CuckooDictionary`.

In addition, the hashed member is removed from `CuckooSet` storage, which should significantly shrink the memory footprint of all sets, especially with small member types.

### Tasks

 - [x] Remove hashed member from set storage
- [x] Clean up set bump process to match dictionary
- [x] Refactor insert method for clarity
