### PR TITLE
Use `FowlerNollVo` 0.2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .package(
             name: "FowlerNollVo", 
             url: "https://github.com/crichez/swift-fowler-noll-vo",
-            .upToNextMinor(from: "0.1.1"))
+            .upToNextMinor(from: "0.2.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/CuckooCollections/CuckooDictionary/CuckooDictionary.swift
+++ b/Sources/CuckooCollections/CuckooDictionary/CuckooDictionary.swift
@@ -48,14 +48,14 @@ where Key : FNVHashable {
 extension CuckooDictionary {
     /// Returns the hash of the provided key using the primary hash function.
     func primaryHash(of key: Key) -> UInt64 {
-        var hasher = FNV1aHasher<UInt64>()
+        var hasher = FNV64a()
         hasher.combine(key)
         return hasher.digest
     }
 
     /// Returns the hash of the provided key using the secondary hash function.
     func secondaryHash(of key: Key) -> UInt64 {
-        var hasher = FNV1Hasher<UInt64>()
+        var hasher = FNV64()
         hasher.combine(key)
         return hasher.digest
     }

--- a/Sources/CuckooCollections/CuckooSet/CuckooSet.swift
+++ b/Sources/CuckooCollections/CuckooSet/CuckooSet.swift
@@ -48,7 +48,7 @@ public struct CuckooSet<Element: FNVHashable> {
     ///
     /// - Returns: The primary hash function digest as an `UInt64`.
     func primaryHash(of member: Element) -> UInt64 {
-        var hasher = FNV1aHasher<UInt64>()
+        var hasher = FNV64a()
         hasher.combine(member)
         return hasher.digest
     }
@@ -61,7 +61,7 @@ public struct CuckooSet<Element: FNVHashable> {
     ///
     /// - Returns: The secondary hash function digest as an `UInt64`.
     func secondaryHash(of member: Element) -> UInt64 {
-        var hasher = FNV1Hasher<UInt64>()
+        var hasher = FNV64()
         hasher.combine(member)
         return hasher.digest
     }
@@ -205,8 +205,8 @@ extension CuckooSet: FNVHashable, Equatable {
     }
 
     public static func == (lhs: Self, rhs: Self) -> Bool {
-        var lhsHasher = FNV1aHasher<UInt64>()
-        var rhsHasher = FNV1aHasher<UInt64>()
+        var lhsHasher = FNV64a()
+        var rhsHasher = FNV64a()
         lhs.hash(into: &lhsHasher)
         rhs.hash(into: &rhsHasher)
         return lhsHasher.digest == rhsHasher.digest


### PR DESCRIPTION
### Objectives

This pull request:
* Bumps the minimum `FowlerNollVo` package version to `0.2.0`
* Replaces calls to `FNV1Hasher` with `FNV64`
* Replaces calls to `FNV1aHasher` with `FNV64a`

### Tasks

- [x] Update `Package.swift`
- [x] Update affected call sites
- [x] Verify all existing tests pass on all platforms