### PR TITLE
Generate Benchmarks & Comparisons

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 on:
   pull_request:
-    branches: [main]
+    branches: [master]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,10 @@ jobs:
         run: swift test
 
       - name: Test iOS
-        run: xcodebuild test -scheme swift-cuckoo-collections -destination "platform=iOS Simulator,name=iPhone 12,OS=15.2"
+        run: xcodebuild test -scheme CuckooCollections -destination "platform=iOS Simulator,name=iPhone 12,OS=15.2"
 
       - name: Test watchOS
-        run: xcodebuild test -scheme swift-cuckoo-collections -destination "platform=watchOS Simulator,name=Apple Watch Series 6 - 44mm,OS=8.3"
+        run: xcodebuild test -scheme CuckooCollections -destination "platform=watchOS Simulator,name=Apple Watch Series 6 - 44mm,OS=8.3"
 
       - name: Test tvOS
-        run: xcodebuild test -scheme swift-cuckoo-collections -destination "platform=tvOS Simulator,name=Apple TV 4K,OS=15.2"
+        run: xcodebuild test -scheme CuckooCollections -destination "platform=tvOS Simulator,name=Apple TV 4K,OS=15.2"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,27 @@
+# The test workflow builds the project and tests it on all supported platforms.
 name: Test
+
 on:
+  # Run this workflow for each pull request that targets the master branch.
   pull_request:
     branches: [master]
+
+  # If your pull request doesn't target master, you can still run this from the Actions tab.
   workflow_dispatch:
 
 jobs:
+  # The job matrix for desktop and server platforms.
   test-standard-platforms:
+
+    # The matrix strategy for this job.
     strategy:
       matrix:
+        # Platforms are named after the GitHub Actions hosted runner identifiers.
         platform:
         - ubuntu-latest
         - macos-latest
         - windows-latest
+        # Include a platform name for each runner.
         include:
         - platform: ubuntu-latest
           name: Ubuntu 20.04
@@ -19,30 +29,45 @@ jobs:
           name: macOS 11
         - platform: windows-latest
           name: Windows Server 2022
+
+    # Name each job after the platform it is running on. 
     name: Test on ${{ matrix.name }}
     runs-on: ${{ matrix.platform }}
+
     steps: 
+      # Checkout the project.
       - uses: actions/checkout@v2
+      # If we are on Windows, install Swift.
       - name: Install Swift
         if: ${{ matrix.platform == 'windows-latest' }}
         uses: MaxDesiatov/swift-windows-action@v1
         with:
+          # There currently is a problem running 5.6.1 on Windows, so use 5.6.
           swift-version: "5.6"
+      # Build sources first.
       - name: Build Sources
         run: swift build
+      # Build tests next.
       - name: Build Tests
         run: swift build --build-tests
+      # Run the test suite.
       - name: Run Tests
         run: swift test
   
-  test-mobile-platforms:
+  # The job matrix for Apple platforms.
+  test-apple-platforms:
+    # Use the latest macos runner.
     runs-on: macos-latest
+
+    # The matric strategy.
     strategy:
       matrix:
+        # The xcodebuild destination identifier for each platform.
         destination:
         - "platform=iOS Simulator,name=iPhone 12,OS=15.2"
         - "platform=tvOS Simulator,name=Apple TV 4K,OS=15.2"
         - "platform=watchOS Simulator,name=Apple Watch Series 6 - 44mm,OS=8.3"
+        # Include a readable name for each platform.
         include:
         - destination: "platform=iOS Simulator,name=iPhone 12,OS=15.2"
           destinationName: iOS 15.2
@@ -50,21 +75,29 @@ jobs:
           destinationName: tvOS 15.2
         - destination: "platform=watchOS Simulator,name=Apple Watch Series 6 - 44mm,OS=8.3"
           destinationName: watchOS 8.3
+  
+    # Name each job according to the platform.
     name: Test on ${{ matrix.destinationName }}
+
+    # Set the scheme name as an environment variable so it can be changed easily.
     env:
-      BUILD_SCHEME: CuckooCollections
-      TEST_SCHEME: swift-cuckoo-collections-Package -target CuckooCollectionsTests
+      SCHEME: CuckooCollections
+
     steps:
+    # Checkout the project.
     - uses: actions/checkout@v2
+    # Build sources.
     - name: Build Sources
       run: > 
-        xcodebuild build -scheme $BUILD_SCHEME 
+        xcodebuild build -scheme $SCHEME 
         -destination "${{ matrix.destination }}"
+    # Build tests.
     - name: Build Tests
       run: > 
-        xcodebuild build-for-testing -scheme $TEST_SCHEME 
+        xcodebuild build-for-testing -scheme $SCHEME 
         -destination "${{ matrix.destination }}"
+    # Run tests.
     - name: Run Tests
       run: > 
-        xcodebuild test -scheme $TEST_SCHEME
+        xcodebuild test -scheme $SCHEME
         -destination "${{ matrix.destination }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,42 +1,67 @@
-# A workflow that builds & tests the package on all supported platforms
-
 name: Test
-
 on:
   pull_request:
-    branches: ['**']
-
+    branches: [main]
   workflow_dispatch:
 
 jobs:
-  test-ubuntu-20:
-    runs-on: ubuntu-20.04
-    steps:
+  test-standard-platforms:
+    strategy:
+      matrix:
+        platform:
+        - ubuntu-latest
+        - macos-latest
+        - windows-latest
+        include:
+        - platform: ubuntu-latest
+          name: Ubuntu 20.04
+        - platform: macos-latest
+          name: macOS 11
+        - platform: windows-latest
+          name: Windows Server 2022
+    name: Test on ${{ matrix.name }}
+    runs-on: ${{ matrix.platform }}
+    steps: 
       - uses: actions/checkout@v2
-      - name: Test
+      - name: Install Swift
+        if: ${{ matrix.platform == 'windows-latest' }}
+        uses: MaxDesiatov/swift-windows-action@v1
+      - name: Build Sources
+        run: swift build
+      - name: Build Tests
+        run: swift build --build-tests
+      - name: Run Tests
         run: swift test
-
-  test-windows:
-    runs-on: windows-2019
+  
+  test-mobile-platforms:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        destination:
+        - "platform=iOS Simulator,name=iPhone 12,OS=15.2"
+        - "platform=tvOS Simulator,name=Apple TV 4K,OS=15.2"
+        - "platform=watchOS Simulator,name=Apple Watch Series 6 - 44mm,OS=8.3"
+        include:
+        - destination: "platform=iOS Simulator,name=iPhone 12,OS=15.2"
+          destinationName: iOS 15.2
+        - destination: "platform=tvOS Simulator,name=Apple TV 4K,OS=15.2"
+          destinationName: tvOS 15.2
+        - destination: "platform=watchOS Simulator,name=Apple Watch Series 6 - 44mm,OS=8.3"
+          destinationName: watchOS 8.3
+    name: Test on ${{ matrix.destinationName }}
+    env:
+      SCHEME: swift-cuckoo-collections-Package
     steps:
-      - uses: actions/checkout@v2
-      - uses: MaxDesiatov/swift-windows-action@v1
-        with:
-          swift-version: "5.5"
-
-  test-apple-platforms:
-    runs-on: macos-11
-    steps:
-      - uses: actions/checkout@v2
-      
-      - name: Test macOS
-        run: swift test
-
-      - name: Test iOS
-        run: xcodebuild test -scheme CuckooCollections -destination "platform=iOS Simulator,name=iPhone 12,OS=15.2"
-
-      - name: Test watchOS
-        run: xcodebuild test -scheme CuckooCollections -destination "platform=watchOS Simulator,name=Apple Watch Series 6 - 44mm,OS=8.3"
-
-      - name: Test tvOS
-        run: xcodebuild test -scheme CuckooCollections -destination "platform=tvOS Simulator,name=Apple TV 4K,OS=15.2"
+    - uses: actions/checkout@v2
+    - name: Build Sources
+      run: > 
+        xcodebuild build -scheme $SCHEME 
+        -destination "${{ matrix.destination }}"
+    - name: Build Tests
+      run: > 
+        xcodebuild build-for-testing -scheme $SCHEME 
+        -destination "${{ matrix.destination }}"
+    - name: Run Tests
+      run: > 
+        xcodebuild test -scheme $SCHEME
+        -destination "${{ matrix.destination }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,18 +50,19 @@ jobs:
           destinationName: watchOS 8.3
     name: Test on ${{ matrix.destinationName }}
     env:
-      SCHEME: swift-cuckoo-collections-Package
+      BUILD_SCHEME: CuckooCollections
+      TEST_SCHEME: swift-cuckoo-collections-Package
     steps:
     - uses: actions/checkout@v2
     - name: Build Sources
       run: > 
-        xcodebuild build -scheme $SCHEME 
+        xcodebuild build -scheme $BUILD_SCHEME 
         -destination "${{ matrix.destination }}"
     - name: Build Tests
       run: > 
-        xcodebuild build-for-testing -scheme $SCHEME 
+        xcodebuild build-for-testing -scheme $TEST_SCHEME 
         -destination "${{ matrix.destination }}"
     - name: Run Tests
       run: > 
-        xcodebuild test -scheme $SCHEME
+        xcodebuild test -scheme $TEST_SCHEME
         -destination "${{ matrix.destination }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         if: ${{ matrix.platform == 'windows-latest' }}
         uses: MaxDesiatov/swift-windows-action@v1
         with:
-          swift-version: "5.6.1"
+          swift-version: "5.6"
       - name: Build Sources
         run: swift build
       - name: Build Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           # There currently is a problem running 5.6.1 on Windows, so use 5.6.
           swift-version: "5.6"
+          shell-action: swift help
       # Build sources first.
       - name: Build Sources
         run: swift build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           # There currently is a problem running 5.6.1 on Windows, so use 5.6.
           swift-version: "5.6"
-          shell-action: swift help
+          shell-action: swift -h
       # Build sources first.
       - name: Build Sources
         run: swift build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Install Swift
         if: ${{ matrix.platform == 'windows-latest' }}
         uses: MaxDesiatov/swift-windows-action@v1
+        with:
+          swift-version: "5.6.1"
       - name: Build Sources
         run: swift build
       - name: Build Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
     name: Test on ${{ matrix.destinationName }}
     env:
       BUILD_SCHEME: CuckooCollections
-      TEST_SCHEME: swift-cuckoo-collections-Package
+      TEST_SCHEME: swift-cuckoo-collections-Package -target CuckooCollectionsTests
     steps:
     - uses: actions/checkout@v2
     - name: Build Sources

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@ DerivedData
 .swiftpm
 .vscode
 Package.resolved
-results
-chart.png
+results.json
+renderedResults.html

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ DerivedData
 .swiftpm
 .vscode
 Package.resolved
+results
+chart.png

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,22 @@
+# Apple utility directory
 .DS_Store
+
+# Build products directory
 .build
+
+# VSCode tasks and launch configurations
 .vscode
+
+# Swift build & resolve output
 Packages
 DerivedData
 Package.resolved
+
+# Benchmark results
 results.json
 renderedResults.html
+
+# Unnecessary XCode information
 .swiftpm/xcode/package.xcworkspace
 .swiftpm/xcode/xcuserdata
 .swiftpm/xcode/xcshareddata/xcbaselines

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
 .DS_Store
 .build
-Packages
-xcuserdata
-DerivedData
-.swiftpm
 .vscode
+Packages
+DerivedData
 Package.resolved
 results.json
 renderedResults.html
+.swiftpm/xcode/package.xcworkspace
+.swiftpm/xcode/xcuserdata
+.swiftpm/xcode/xcshareddata/xcbaselines
+.swiftpm/xcode/xcshareddata/xcschemes/Benchmarks.xcscheme
+.swiftpm/xcode/xcshareddata/xcschemes/swift-cuckoo-collections-Package.xcscheme

--- a/.swiftpm/xcode/xcshareddata/xcschemes/CuckooCollections.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/CuckooCollections.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CuckooCollections"
+               BuildableName = "CuckooCollections"
+               BlueprintName = "CuckooCollections"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CuckooCollectionsTests"
+               BuildableName = "CuckooCollectionsTests"
+               BlueprintName = "CuckooCollectionsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CuckooCollections"
+            BuildableName = "CuckooCollections"
+            BlueprintName = "CuckooCollections"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.swift
+++ b/Package.swift
@@ -1,32 +1,32 @@
 // swift-tools-version:5.5
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "swift-cuckoo-collections",
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "CuckooCollections",
             targets: ["CuckooCollections"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
         .package(
-            name: "FowlerNollVo", 
             url: "https://github.com/crichez/swift-fowler-noll-vo",
-            .upToNextMinor(from: "0.2.0"))
+            .upToNextMinor(from: "0.2.0")),
+        .package(
+            url: "https://github.com/apple/swift-collections-benchmark", 
+            .upToNextMajor(from: "0.0.1")),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "CuckooCollections",
-            dependencies: ["FowlerNollVo"]),
+            dependencies: [.product(name: "FowlerNollVo", package: "swift-fowler-noll-vo")]),
         .testTarget(
             name: "CuckooCollectionsTests",
             dependencies: ["CuckooCollections"]),
+
+        .executableTarget(name: "Benchmarks", dependencies: [
+            "CuckooCollections", 
+            .product(name: "CollectionsBenchmark", package: "swift-collections-benchmark")]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -2,31 +2,57 @@
 
 import PackageDescription
 
+#if os(Windows)
+
+// We cannot build swift-collections-benchmark on Windows, so exclude it from dependencies
+let dependencies: [Package.Dependency] = [
+    .package(
+        url: "https://github.com/crichez/swift-fowler-noll-vo",
+        .upToNextMinor(from: "0.2.0")),
+]
+
+// We do not declare the Benchmarks target on Windows
+let targets: [Target] = [
+    .target(
+        name: "CuckooCollections",
+        dependencies: [.product(name: "FowlerNollVo", package: "swift-fowler-noll-vo")]),
+    .testTarget(
+        name: "CuckooCollectionsTests",
+        dependencies: ["CuckooCollections"]),
+]
+
+#else
+
+// On all other platforms, we assume this builds fine.
+let dependencies: [Package.Dependency] = [
+    .package(
+        url: "https://github.com/crichez/swift-fowler-noll-vo",
+        .upToNextMinor(from: "0.2.0")),
+    .package(
+        url: "https://github.com/apple/swift-collections-benchmark", 
+        .upToNextMajor(from: "0.0.1")),
+]
+
+let targets: [Target] = [
+    .target(
+        name: "CuckooCollections",
+        dependencies: [.product(name: "FowlerNollVo", package: "swift-fowler-noll-vo")]),
+    .testTarget(
+        name: "CuckooCollectionsTests",
+        dependencies: ["CuckooCollections"]),
+    .executableTarget(name: "Benchmarks", dependencies: [
+        "CuckooCollections", 
+        .product(name: "CollectionsBenchmark", package: "swift-collections-benchmark")]),
+]
+
+#endif
+
+// Targets and dependencies are declared above.
 let package = Package(
     name: "swift-cuckoo-collections",
     products: [
-        .library(
-            name: "CuckooCollections",
-            targets: ["CuckooCollections"]),
+        .library(name: "CuckooCollections", targets: ["CuckooCollections"]),
     ],
-    dependencies: [
-        .package(
-            url: "https://github.com/crichez/swift-fowler-noll-vo",
-            .upToNextMinor(from: "0.2.0")),
-        .package(
-            url: "https://github.com/apple/swift-collections-benchmark", 
-            .upToNextMajor(from: "0.0.1")),
-    ],
-    targets: [
-        .target(
-            name: "CuckooCollections",
-            dependencies: [.product(name: "FowlerNollVo", package: "swift-fowler-noll-vo")]),
-        .testTarget(
-            name: "CuckooCollectionsTests",
-            dependencies: ["CuckooCollections"]),
-
-        .executableTarget(name: "Benchmarks", dependencies: [
-            "CuckooCollections", 
-            .product(name: "CollectionsBenchmark", package: "swift-collections-benchmark")]),
-    ]
+    dependencies: dependencies,
+    targets: targets
 )

--- a/Sources/Benchmarks/main.swift
+++ b/Sources/Benchmarks/main.swift
@@ -1,0 +1,31 @@
+//
+//  main.swift
+//
+//
+//  Created by Christopher Richez on May 27th 2022
+//
+
+import CollectionsBenchmark
+import CuckooCollections
+
+var benchmark = Benchmark(title: "CuckooCollections Benchmark")
+
+benchmark.add(title: "CuckooSet<Int> Insert", input: [Int].self) { input in
+    var testSet = CuckooSet<Int>()
+    return { timer in 
+        for value in input {
+            testSet.insert(value)
+        }
+    }
+}
+
+benchmark.add(title: "CuckooSet<Int> Contains", input: [Int].self) { input in 
+    let testSet = CuckooSet(input)
+    return { timer in 
+        for value in input {
+            precondition(testSet.contains(value))
+        }
+    }
+}
+
+benchmark.main()

--- a/Sources/Benchmarks/main.swift
+++ b/Sources/Benchmarks/main.swift
@@ -28,4 +28,25 @@ benchmark.add(title: "CuckooSet<Int> Contains", input: [Int].self) { input in
     }
 }
 
+benchmark.add(title: "CuckooDictionary<Int, Bool> Insert", input: [Int].self) { input in 
+    var testDict = CuckooDictionary<Int, Bool>()
+    return { timer in 
+        for value in input {
+            testDict[value] = .random()
+        }
+    }
+}
+
+benchmark.add(title: "CuckooDictionary<Int, Bool> Lookup", input: [Int].self) { input in 
+    var testDict = CuckooDictionary<Int, Bool>(capacity: input.count * 2)
+    for value in input {
+        testDict[value] = .random()
+    }
+    return { timer in 
+        for value in input {
+            blackHole(testDict[value])
+        }
+    }
+}
+
 benchmark.main()


### PR DESCRIPTION
### Objectives

This PR  configures dependencies to support benchmarking without affecting compatibility.

### Implementation

Benchmarking support is provided by the [swift-collections-benchmark](https://github.com/apple/swift-collections-benchmark) package. 

A new executable target is available named "Benchmark." This target is not available on Windows, and isn't built by default on Apple platforms (except macOS). To learn more about generating benchmarks for your pull requests, see the docs on the project's README.
