### PR TITLE
Use Pointers to store CuckooSet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
 
     # The matrix strategy for this job.
     strategy:
+      fail-fast: false
       matrix:
         # Platforms are named after the GitHub Actions hosted runner identifiers.
         platform:
@@ -62,6 +63,7 @@ jobs:
 
     # The matric strategy.
     strategy:
+      fail-fast: false
       matrix:
         # The xcodebuild destination identifier for each platform.
         destination:

--- a/Sources/CuckooCollections/CuckooSet/CuckooSet.swift
+++ b/Sources/CuckooCollections/CuckooSet/CuckooSet.swift
@@ -23,13 +23,13 @@ public struct CuckooSet<Element: FNVHashable> {
     /// The theoretical maximum number of members this set can contain.
     ///
     /// - Note: `CuckooSet` doubles its capacity when `count` reaches roughly half of `capacity`.
-    public var capacity: Int { 
+    internal(set) public var capacity: Int { 
         get { buckets.capacity }
         set { buckets.capacity = newValue }
     }
 
     /// The number of members contained in this set.
-    public var count: Int { 
+    internal(set) public var count: Int { 
         get { buckets.count }
         set { buckets.count = newValue }
     }

--- a/Sources/CuckooCollections/CuckooSet/CuckooStorage.swift
+++ b/Sources/CuckooCollections/CuckooSet/CuckooStorage.swift
@@ -1,0 +1,42 @@
+//
+//  CuckooHashTable.swift
+//
+//
+//  Created by Christopher Richez on June 17 2022
+//
+
+/// Storage for a cuckoo hash table.
+class CuckooStorage<Element> {
+    /// The base pointer to the element storage.
+    private let basePointer: UnsafeMutablePointer<Element?>
+    
+    /// The number of buckets in the hash table.
+    var capacity: Int
+    
+    /// The number of occupied buckets in the hash table.
+    var count: Int
+    
+    /// Initializes storage by allocating a buffer of the specified capacity.
+    init(capacity: Int) {
+        self.basePointer = .allocate(capacity: capacity)
+        self.basePointer.initialize(repeating: nil, count: capacity)
+        self.capacity = capacity
+        self.count = 0
+    }
+    
+    deinit {
+        basePointer.deinitialize(count: capacity)
+        basePointer.deallocate()
+    }
+}
+
+extension CuckooStorage {
+    subscript(_ offset: Int) -> Element? {
+        get {
+            basePointer.advanced(by: offset).pointee
+        }
+        set {
+            basePointer.advanced(by: offset).pointee = newValue
+        }
+    }
+}

--- a/Sources/CuckooCollections/CuckooSet/CuckooStorage.swift
+++ b/Sources/CuckooCollections/CuckooSet/CuckooStorage.swift
@@ -8,7 +8,7 @@
 /// Storage for a cuckoo hash table.
 class CuckooStorage<Element> {
     /// The base pointer to the element storage.
-    private let basePointer: UnsafeMutablePointer<Element?>
+    let basePointer: UnsafeMutablePointer<Element?>
     
     /// The number of buckets in the hash table.
     var capacity: Int
@@ -22,6 +22,14 @@ class CuckooStorage<Element> {
         self.basePointer.initialize(repeating: nil, count: capacity)
         self.capacity = capacity
         self.count = 0
+    }
+
+    /// Initializes storage by copying the provided storage.
+    init(copying other: CuckooStorage) {
+        self.basePointer = .allocate(capacity: other.capacity)
+        self.basePointer.initialize(from: other.basePointer, count: other.capacity)
+        self.capacity = other.capacity
+        self.count = other.count
     }
     
     deinit {

--- a/Sources/CuckooCollections/CuckooSet/SetAlgebra.swift
+++ b/Sources/CuckooCollections/CuckooSet/SetAlgebra.swift
@@ -17,7 +17,7 @@ extension CuckooSet: SetAlgebra {
         let bucket2 = bucket(for: hash2)
         // Check both buckets
         for bucket in [bucket1, bucket2] {
-            if let memberFound = buckets[bucket] {
+            if let memberFound = contentsOfBucket(at: bucket) {
                 let foundHash1 = primaryHash(of: memberFound)
                 let foundHash2 = secondaryHash(of: memberFound)
                 if foundHash1 == hash1 && foundHash2 == hash2 {
@@ -126,7 +126,7 @@ extension CuckooSet: SetAlgebra {
         let bucket2 = bucket(for: hash2)
         // Check for an existing member at both buckets
         for bucket in [bucket1, bucket2] {
-            if let memberFound = buckets[bucket] {
+            if let memberFound = contentsOfBucket(at: bucket) {
                 let memberFoundHash1 = primaryHash(of: memberFound)
                 let memberFoundHash2 = secondaryHash(of: memberFound)
                 if memberFoundHash1 == hash1 && memberFoundHash2 == hash2 {
@@ -135,9 +135,9 @@ extension CuckooSet: SetAlgebra {
             }
         }
         // If no existing member was found, check the primary bucket
-        if buckets[bucket1] == nil {
+        if contentsOfBucket(at: bucket1) == nil {
             // If it's empty, assign the new member and increment count
-            buckets[bucket1] = newMember
+            overwriteBucket(at: bucket1, with: newMember)
             count += 1
             return (inserted: true, memberAfterInsert: newMember)
         } else {
@@ -171,11 +171,11 @@ extension CuckooSet: SetAlgebra {
         let bucket2 = bucket(for: hash2)
         // Check both buckets
         for bucket in [bucket1, bucket2] {
-            if let memberFound = buckets[bucket] {
+            if let memberFound = contentsOfBucket(at: bucket) {
                 let foundHash1 = primaryHash(of: memberFound)
                 let foundHash2 = secondaryHash(of: memberFound)
                 if foundHash1 == hash1 && foundHash2 == hash2 {
-                    buckets[bucket1] = nil
+                    overwriteBucket(at: bucket, with: nil)
                     count -= 1
                     return member
                 }

--- a/Sources/CuckooCollections/CuckooSet/SetAlgebra.swift
+++ b/Sources/CuckooCollections/CuckooSet/SetAlgebra.swift
@@ -66,6 +66,7 @@ extension CuckooSet: SetAlgebra {
     // MARK: Algebra
 
     public mutating func formUnion(_ otherSet: Self) {
+        copyOnWrite()
         insert(contentsOf: otherSet)
     }
 
@@ -76,6 +77,7 @@ extension CuckooSet: SetAlgebra {
     }
 
     public mutating func formIntersection(_ otherSet: Self) {
+        copyOnWrite()
         for element in self where !otherSet.contains(element) {
             remove(element)
         }
@@ -88,6 +90,7 @@ extension CuckooSet: SetAlgebra {
     }
 
     public mutating func formSymmetricDifference(_ otherSet: Self) {
+        copyOnWrite()
         for element in otherSet where !self.insert(element).inserted {
             remove(element)
         }
@@ -100,6 +103,7 @@ extension CuckooSet: SetAlgebra {
     }
 
     public mutating func subtract(_ otherSet: Self) {
+        copyOnWrite()
         for element in otherSet {
             remove(element)
         }
@@ -117,6 +121,7 @@ extension CuckooSet: SetAlgebra {
     public mutating func insert(
         _ newMember: Element
     ) -> (inserted: Bool, memberAfterInsert: Element) {
+        copyOnWrite()
         // Keep the load factor of the hash table under 0.5
         if capacity < count * 2 { expand() }
         // Get the hashes and buckets for the new member
@@ -164,6 +169,7 @@ extension CuckooSet: SetAlgebra {
     /// Removes the specified element from the set.
     @discardableResult
     public mutating func remove(_ member: Element) -> Element? {
+        copyOnWrite()
         // Get the hashes and buckets for the member to remove
         let hash1 = primaryHash(of: member)
         let bucket1 = bucket(for: hash1)

--- a/Sources/CuckooCollections/CuckooSet/SetAlgebra.swift
+++ b/Sources/CuckooCollections/CuckooSet/SetAlgebra.swift
@@ -17,7 +17,7 @@ extension CuckooSet: SetAlgebra {
         let bucket2 = bucket(for: hash2)
         // Check both buckets
         for bucket in [bucket1, bucket2] {
-            if let memberFound = contentsOfBucket(at: bucket) {
+            if let memberFound = buckets[bucket] {
                 let foundHash1 = primaryHash(of: memberFound)
                 let foundHash2 = secondaryHash(of: memberFound)
                 if foundHash1 == hash1 && foundHash2 == hash2 {
@@ -126,7 +126,7 @@ extension CuckooSet: SetAlgebra {
         let bucket2 = bucket(for: hash2)
         // Check for an existing member at both buckets
         for bucket in [bucket1, bucket2] {
-            if let memberFound = contentsOfBucket(at: bucket) {
+            if let memberFound = buckets[bucket] {
                 let memberFoundHash1 = primaryHash(of: memberFound)
                 let memberFoundHash2 = secondaryHash(of: memberFound)
                 if memberFoundHash1 == hash1 && memberFoundHash2 == hash2 {
@@ -135,9 +135,9 @@ extension CuckooSet: SetAlgebra {
             }
         }
         // If no existing member was found, check the primary bucket
-        if contentsOfBucket(at: bucket1) == nil {
+        if buckets[bucket1] == nil {
             // If it's empty, assign the new member and increment count
-            overwriteBucket(at: bucket1, with: newMember)
+            buckets[bucket1] = newMember
             count += 1
             return (inserted: true, memberAfterInsert: newMember)
         } else {
@@ -171,11 +171,11 @@ extension CuckooSet: SetAlgebra {
         let bucket2 = bucket(for: hash2)
         // Check both buckets
         for bucket in [bucket1, bucket2] {
-            if let memberFound = contentsOfBucket(at: bucket) {
+            if let memberFound = buckets[bucket] {
                 let foundHash1 = primaryHash(of: memberFound)
                 let foundHash2 = secondaryHash(of: memberFound)
                 if foundHash1 == hash1 && foundHash2 == hash2 {
-                    overwriteBucket(at: bucket, with: nil)
+                    buckets[bucket] = nil
                     count -= 1
                     return member
                 }

--- a/Tests/CuckooCollectionsTests/CuckooSet/CuckooStorageTests.swift
+++ b/Tests/CuckooCollectionsTests/CuckooSet/CuckooStorageTests.swift
@@ -1,0 +1,26 @@
+//
+//  CuckooStorageTests.swift
+//
+//
+//  Created by Christopher Richez on June 18 2022
+//
+
+import XCTest
+@testable import CuckooCollections
+
+class CuckooStorageTests: XCTestCase {
+    /// Asserts mutating a copy of a set does not mutate the original.
+    func testValueSemantics() {
+        let original: CuckooSet = ["test", "one", "two"]
+        var copy = original
+        copy.insert("three")
+        XCTAssertFalse(original.contains("three"))
+    }
+
+    /// Asserts copies of a set reference the same memory.
+    func testReferenceSemantics() {
+        let original: CuckooSet = [1.295]
+        let copy = original
+        XCTAssertEqual(original.buckets.basePointer, copy.buckets.basePointer)
+    }
+}


### PR DESCRIPTION
### Objectives

This pull request improves the per-insert performance of `CuckooSet` by changing its backing storage from `Array` to `UnsafeMutablePointer`.

### Implementation

**When initializing a set**, every pointer in the buffer is initialized to `nil` to indicate an empty bucket. This operation still takes linear time as the initializer must iterate through every pointer in the buffer. The buffer's header is empty. Instead of storing `capacity` and `count` in the header, they are stored inline at the class definition. This may change to simplify copy-on-write semantics, but for now should provide meager performance benefits.

### Performance

Benchmark output on the `CuckooSet<Int> Insert` task outputs the following comparison statistics:
```
Tasks with difference scores larger than 1.05:
  Score   Sum     Improvements Regressions  Name
  1.341   1.341   1.341(#76)   1.000(#0)    CuckooSet<Int> Insert (*)
```
The `CuckooSet<Int> Contains` task showed no significant improvement.

Most of this improvement is associated with the removed bounds checks associated with unsafe pointers. This significantly reduces memory safety, but our tests guarantee this implementation is safe.