### PR TITLE
Re-Implement CuckooSet.removeAll()

### DIFF
--- a/Sources/CuckooCollections/CuckooSet/CuckooSet.swift
+++ b/Sources/CuckooCollections/CuckooSet/CuckooSet.swift
@@ -155,6 +155,11 @@ public struct CuckooSet<Element: FNVHashable> {
         cuckooSet.insert(contentsOf: otherCollection)
         self = cuckooSet
     }
+
+    /// Removes all members in the set and resets the storage to the default size.
+    public mutating func removeAll() {
+        buckets = CuckooStorage(capacity: 32)
+    }
 }
 
 extension CuckooSet: Sequence {

--- a/Tests/CuckooCollectionsTests/CuckooSet/CuckooSetTests.swift
+++ b/Tests/CuckooCollectionsTests/CuckooSet/CuckooSetTests.swift
@@ -114,4 +114,17 @@ class CuckooSetTests: XCTestCase {
             XCTAssertTrue(testSet.contains(member))
         }
     }
+
+    /// Asserts calling `removeAll()` removes all members are resets storage capacity.
+    func testRemoveAll() {
+        var testSet = CuckooSet<String>(capacity: 64) 
+        testSet.insert(contentsOf: ["this", "is", "a", "test"])
+        XCTAssertEqual(testSet.count, 4)
+        XCTAssertEqual(testSet.capacity, 64)
+        testSet.removeAll()
+        XCTAssertEqual(testSet.count, 0)
+        XCTAssertEqual(testSet.capacity, 32)
+        var iterator = testSet.makeIterator()
+        XCTAssertNil(iterator.next())
+    }
 }


### PR DESCRIPTION
## Objective

This pull request re-implements the `CuckooSet.removeAll()` method that was previously removed by accident. This closes #18.

## Implementation

This PR takes advantage of the changes in #20 by simply re-allocating the set's storage to a default-sized empty instance.
```swift
public func removeAll() {
    buckets = CuckooStorage(capacity: 32)
}
```

In the event this storage is shared with another set, it should remain unaffected. If this storage is uniquely refenced, ARC will deinitialize it.

## Impact on Source Stability

This PR restores a part of the original public API. Compared to the last commit, this is an additive change.
