### PR TITLE
Rename Benchmark Tasks

### DIFF
--- a/Sources/Benchmarks/main.swift
+++ b/Sources/Benchmarks/main.swift
@@ -21,25 +21,108 @@ import CuckooCollections
 
 var benchmark = Benchmark(title: "CuckooCollections Benchmark")
 
-benchmark.add(title: "CuckooSet<Int> Insert", input: [Int].self) { input in
+// MARK: CuckooSet
+
+benchmark.add(title: "set/insert", input: [Int].self) { input in
     var testSet = CuckooSet<Int>()
     return { timer in 
         for value in input {
-            testSet.insert(value)
+            blackHole(testSet.insert(value).inserted)
         }
     }
 }
 
-benchmark.add(title: "CuckooSet<Int> Contains", input: [Int].self) { input in 
+benchmark.add(title: "set/contains", input: [Int].self) { input in
     let testSet = CuckooSet(input)
     return { timer in 
         for value in input {
-            precondition(testSet.contains(value))
+            blackHole(testSet.contains(value))
         }
     }
 }
 
-benchmark.add(title: "CuckooDictionary<Int, Bool> Insert", input: [Int].self) { input in 
+benchmark.add(title: "set/remove", input: [Int].self) { input in
+    var testSet = CuckooSet(input)
+    return { timer in
+        for value in input {
+            blackHole(testSet.remove(value))
+        }
+    }
+}
+
+benchmark.add(title: "set/isSubset", input: [Int].self) { input in
+    let superset = CuckooSet(input)
+    let subset = CuckooSet(input.dropFirst())
+    return { timer in
+        blackHole(subset.isSubset(of: superset))
+    }
+}
+
+benchmark.add(title: "set/isStrictSubset", input: [Int].self) { input in
+    let superset = CuckooSet(input)
+    let subset = CuckooSet(input.dropFirst())
+    return { timer in
+        blackHole(subset.isStrictSubset(of: superset))
+    }
+}
+
+benchmark.add(title: "set/isSuperset", input: [Int].self) { input in
+    let superset = CuckooSet(input)
+    let subset = CuckooSet(input.dropFirst())
+    return { timer in
+        blackHole(superset.isSuperset(of: subset))
+    }
+}
+
+benchmark.add(title: "set/isStrictSuperset", input: [Int].self) { input in
+    let superset = CuckooSet(input)
+    let subset = CuckooSet(input.dropFirst())
+    return { timer in
+        blackHole(superset.isStrictSuperset(of: subset))
+    }
+}
+
+benchmark.add(title: "set/isDisjoint", input: [Int].self) { input in
+    let firstHalf = CuckooSet(input.dropLast(input.count / 2))
+    let secondHalf = CuckooSet(input.dropFirst(input.count / 2))
+    return { timer in
+        blackHole(firstHalf.isDisjoint(with: secondHalf))
+    }
+}
+
+benchmark.add(title: "set/union", input: [Int].self) { input in
+    let firstHalf = CuckooSet(input.dropLast(input.count / 2))
+    let secondHalf = CuckooSet(input.dropFirst(input.count / 2))
+    return { timer in
+        blackHole(firstHalf.union(secondHalf))
+    }
+}
+
+benchmark.add(title: "set/intersection", input: [Int].self) { input in
+    let firstHalf = CuckooSet(input.dropLast(input.count / 2 - 1))
+    let secondHalf = CuckooSet(input.dropFirst(input.count / 2))
+    return { timer in
+        blackHole(firstHalf.intersection(secondHalf))
+    }
+}
+
+benchmark.add(title: "set/symmetricDifference", input: [Int].self) { input in
+    let testSet = CuckooSet(input)
+    let firstHalf = CuckooSet(input.dropLast(input.count / 2))
+    return { timer in
+        blackHole(testSet.symmetricDifference(firstHalf))
+    }
+}
+
+benchmark.add(title: "set/subtract", input: [Int].self) { input in
+    var testSet = CuckooSet(input)
+    let firstHalf = CuckooSet(input.dropLast(input.count / 2))
+    return { timer in
+        testSet.subtract(firstHalf)
+    }
+}
+
+benchmark.add(title: "dict/insert", input: [Int].self) { input in
     var testDict = CuckooDictionary<Int, Bool>()
     return { timer in 
         for value in input {
@@ -48,7 +131,17 @@ benchmark.add(title: "CuckooDictionary<Int, Bool> Insert", input: [Int].self) { 
     }
 }
 
-benchmark.add(title: "CuckooDictionary<Int, Bool> Lookup", input: [Int].self) { input in 
+benchmark.add(title: "dict/remove", input: [Int].self) { input in
+    var testDict = CuckooDictionary<Int, Bool>(capacity: input.count * 2)
+    for value in input {
+        testDict[value] = .random()
+    }
+    return { timer in
+        
+    }
+}
+
+benchmark.add(title: "dict/lookup", input: [Int].self) { input in
     var testDict = CuckooDictionary<Int, Bool>(capacity: input.count * 2)
     for value in input {
         testDict[value] = .random()

--- a/Sources/Benchmarks/main.swift
+++ b/Sources/Benchmarks/main.swift
@@ -50,94 +50,12 @@ benchmark.add(title: "set/remove", input: [Int].self) { input in
     }
 }
 
-benchmark.add(title: "set/isSubset", input: [Int].self) { input in
-    let superset = CuckooSet(input)
-    let subset = CuckooSet(input.dropFirst())
-    return { timer in
-        blackHole(subset.isSubset(of: superset))
-    }
-}
-
-benchmark.add(title: "set/isStrictSubset", input: [Int].self) { input in
-    let superset = CuckooSet(input)
-    let subset = CuckooSet(input.dropFirst())
-    return { timer in
-        blackHole(subset.isStrictSubset(of: superset))
-    }
-}
-
-benchmark.add(title: "set/isSuperset", input: [Int].self) { input in
-    let superset = CuckooSet(input)
-    let subset = CuckooSet(input.dropFirst())
-    return { timer in
-        blackHole(superset.isSuperset(of: subset))
-    }
-}
-
-benchmark.add(title: "set/isStrictSuperset", input: [Int].self) { input in
-    let superset = CuckooSet(input)
-    let subset = CuckooSet(input.dropFirst())
-    return { timer in
-        blackHole(superset.isStrictSuperset(of: subset))
-    }
-}
-
-benchmark.add(title: "set/isDisjoint", input: [Int].self) { input in
-    let firstHalf = CuckooSet(input.dropLast(input.count / 2))
-    let secondHalf = CuckooSet(input.dropFirst(input.count / 2))
-    return { timer in
-        blackHole(firstHalf.isDisjoint(with: secondHalf))
-    }
-}
-
-benchmark.add(title: "set/union", input: [Int].self) { input in
-    let firstHalf = CuckooSet(input.dropLast(input.count / 2))
-    let secondHalf = CuckooSet(input.dropFirst(input.count / 2))
-    return { timer in
-        blackHole(firstHalf.union(secondHalf))
-    }
-}
-
-benchmark.add(title: "set/intersection", input: [Int].self) { input in
-    let firstHalf = CuckooSet(input.dropLast(input.count / 2 - 1))
-    let secondHalf = CuckooSet(input.dropFirst(input.count / 2))
-    return { timer in
-        blackHole(firstHalf.intersection(secondHalf))
-    }
-}
-
-benchmark.add(title: "set/symmetricDifference", input: [Int].self) { input in
-    let testSet = CuckooSet(input)
-    let firstHalf = CuckooSet(input.dropLast(input.count / 2))
-    return { timer in
-        blackHole(testSet.symmetricDifference(firstHalf))
-    }
-}
-
-benchmark.add(title: "set/subtract", input: [Int].self) { input in
-    var testSet = CuckooSet(input)
-    let firstHalf = CuckooSet(input.dropLast(input.count / 2))
-    return { timer in
-        testSet.subtract(firstHalf)
-    }
-}
-
 benchmark.add(title: "dict/insert", input: [Int].self) { input in
     var testDict = CuckooDictionary<Int, Bool>()
     return { timer in 
         for value in input {
             testDict[value] = .random()
         }
-    }
-}
-
-benchmark.add(title: "dict/remove", input: [Int].self) { input in
-    var testDict = CuckooDictionary<Int, Bool>(capacity: input.count * 2)
-    for value in input {
-        testDict[value] = .random()
-    }
-    return { timer in
-        
     }
 }
 


### PR DESCRIPTION
## Objectives

This pull request renames the benchmark tasks to a consistent convention. The history explores the requests in #17 and decided to close #17 without adding new benchmarks.

### Note on #17

The benchmark tasks for set algebra operations ended up being highly variable, and no more than a poor reflection of the performance of insert and remove operations. The new tasks were introduced on this branch, but then removed in favor of their component operations.

## Naming Convention

Each task is now named `collection/method-options`. For example:
* `set/insert`
* `dict/lookup`
* `set/insert-reservingCapacity`
